### PR TITLE
Make mypy_plugin compatible with mypy>=0.730 

### DIFF
--- a/adt/__init__.py
+++ b/adt/__init__.py
@@ -1,2 +1,7 @@
+from typing import TYPE_CHECKING
+
 from .case import Case
 from .decorator import adt
+
+if TYPE_CHECKING:
+    from .case import CaseConstructor

--- a/adt/decorator.py
+++ b/adt/decorator.py
@@ -1,3 +1,4 @@
+# mypy: no-warn-unused-ignores
 from enum import Enum
 from typing import Any, Callable, Type, TypeVar, no_type_check
 
@@ -23,7 +24,8 @@ def adt(cls):
                 f'Annotation {k} should be a Case[…] constructor, got {constructor!r} instead'
             )
 
-    cls._Key = Enum('_Key', list(caseConstructors.keys()))
+    cls._Key = Enum(  # type: ignore
+        '_Key', list(caseConstructors.keys()))
 
     _installInit(cls)
     _installRepr(cls)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 yapf==0.27.0
-mypy==0.711
+mypy>=0.711, <=0.761
 coverage==4.5.3
 hypothesis==4.24.5
 coveralls==1.8.1

--- a/tests/test_mypy_plugin.py
+++ b/tests/test_mypy_plugin.py
@@ -7,24 +7,6 @@ import io
 from typing import List, Optional
 
 
-class SimpleBuffer(io.TextIOBase):
-    """Simple memory buffer that behaves like a file"""
-
-    def __init__(self) -> None:
-        self.__buffer: List[str] = []
-
-    def write(self, text: str) -> int:
-        self.__buffer.append(text)
-        print(text, end="")
-        return len(text)
-
-    def read(self, size: Optional[int] = None) -> str:
-        return ''.join(self.__buffer)
-
-    def __str__(self) -> str:
-        return self.read()
-
-
 class TestMyPyPlugin(unittest.TestCase):
     def test_issue21(self) -> None:
         self._call_mypy_on_source_file("issue21.py")
@@ -54,9 +36,7 @@ class TestMyPyPlugin(unittest.TestCase):
                          source_file_name))
 
     def _call_mypy_on_path(self, testfile: str) -> None:
-        output = SimpleBuffer()
         try:
-            mypy.main.main(  # type: ignore
-                None, output, sys.stderr, args=[testfile])
+            mypy.main.main(None, sys.stdout, sys.stderr, args=[testfile])
         except SystemExit:
-            self.fail(msg="Error during type-check:\n{}".format(output))
+            self.fail(msg="Error during type-check")

--- a/tests/test_mypy_plugin.py
+++ b/tests/test_mypy_plugin.py
@@ -3,28 +3,26 @@ import mypy.main
 import mypy.version
 import os
 import sys
-import io
-from typing import List, Optional
 
 
 class TestMyPyPlugin(unittest.TestCase):
     def test_issue21(self) -> None:
         self._call_mypy_on_source_file("issue21.py")
 
-    def _test_issue25(self) -> None:
-        # TODO: This is a deactivated test for issue #25.
+    @unittest.expectedFailure  # Issue #26 is still unfixed
+    def test_issue25(self) -> None:
         # Activate it when working on it.
         # cf. https://github.com/jspahrsummers/adt/issues/25
         self._call_mypy_on_source_file("issue25.py")
 
-    def _test_issue26(self) -> None:
-        # TODO: This is a deactivated test for issue #26.
+    @unittest.expectedFailure  # Issue #26 is still unfixed
+    def test_issue26(self) -> None:
         # Activate it when working on it.
         # cf. https://github.com/jspahrsummers/adt/issues/26
         self._call_mypy_on_source_file("issue26.py")
 
-    def _test_readme_examples(self) -> None:
-        # TODO: This fails because of issue #26. Deactivated this test.
+    @unittest.expectedFailure  # Fails because issue #26 is still unfixed
+    def test_readme_examples(self) -> None:
         self._call_mypy_on_source_file("readme_examples.py")
 
     def _call_mypy_on_source_file(self, source_file_name: str) -> None:


### PR DESCRIPTION
This introduces a new hook to change the type `mypy` sees before the semantic analyzer runs. This is briefly discussed in #21 

The other issues raised in my comment turned out to be bugs that already existed for the old mypy version, too. These are not addressed with this fix.

This has been tested with `mypy==0.711` and `mypy=0.761`