### PR TITLE
Just install adt, not tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -12,7 +12,7 @@ setup(name='algebraic-data-types',
       long_description_content_type='text/markdown',
       license='MIT',
       url='https://github.com/jspahrsummers/adt',
-      packages=find_packages(),
+      packages=['adt'],
       package_data={'adt': ['py.typed']},
       classifiers=[
           "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Hey there! I really like this package. Pattern matching in Python, mypy integration. Cool stuff.

A small thing that I ran into while trying it out: `find_packages` installs both `adt` and `tests` packages. The `tests` package is causing some import name collisions and minor inconveniences for me. I think it'd be a bit more considerate to just install `adt` :-)